### PR TITLE
Simplify recent posts listing

### DIFF
--- a/assets/css/local.css
+++ b/assets/css/local.css
@@ -295,6 +295,10 @@ hr {
         list-style: none;
     }
     .post-list-item {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 1rem;
         padding: 1rem 0;
         border-bottom: 1px solid var(--nav-border-color);
 
@@ -306,14 +310,34 @@ hr {
             border-bottom: 0;
         }
         h3 {
-            margin-bottom: 0.25rem;
+            flex: 1 1 auto;
+            margin-bottom: 0;
         }
     }
     .post-list-meta {
         display: flex;
-        flex-wrap: wrap;
+        flex: 0 0 auto;
+        flex-wrap: nowrap;
+        justify-content: flex-end;
         gap: 0.25rem 1rem;
         color: var(--font-muted-color);
         font-size: 0.9rem;
+        text-align: right;
+    }
+}
+@media screen and (max-width: 600px) {
+    .home-section {
+        .post-list-item {
+            display: block;
+
+            h3 {
+                margin-bottom: 0.25rem;
+            }
+        }
+        .post-list-meta {
+            flex-wrap: wrap;
+            justify-content: flex-start;
+            text-align: left;
+        }
     }
 }

--- a/assets/css/local.css
+++ b/assets/css/local.css
@@ -289,4 +289,31 @@ hr {
     h2 {
         text-align: center;
     }
+    .post-list {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+    }
+    .post-list-item {
+        padding: 1rem 0;
+        border-bottom: 1px solid var(--nav-border-color);
+
+        &:first-child {
+            padding-top: 0;
+        }
+        &:last-child {
+            padding-bottom: 0;
+            border-bottom: 0;
+        }
+        h3 {
+            margin-bottom: 0.25rem;
+        }
+    }
+    .post-list-meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.25rem 1rem;
+        color: var(--font-muted-color);
+        font-size: 0.9rem;
+    }
 }

--- a/assets/css/local.css
+++ b/assets/css/local.css
@@ -319,13 +319,18 @@ hr {
         flex: 0 0 auto;
         flex-wrap: nowrap;
         justify-content: flex-end;
-        gap: 0.25rem 1rem;
+        gap: 0.25rem;
         color: var(--font-muted-color);
         font-size: 0.9rem;
         text-align: right;
+
+        time,
+        span {
+            color: var(--font-color);
+        }
     }
 }
-@media screen and (max-width: 600px) {
+@media screen and (max-width: 800px) {
     .home-section {
         .post-list-item {
             display: block;

--- a/assets/css/tags.css
+++ b/assets/css/tags.css
@@ -65,5 +65,8 @@
 @media (max-width: 600px) {
     .tags {
         flex-direction: column;
+        .tag {
+            margin: 0.25rem 0;
+        }
     }
 }

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -27,16 +27,28 @@
 {{- end }}
 <section class="home-section">
     <h2>Recent Posts</h2>
-    <div class="cards">
+    <ul class="post-list">
 {{ range first 8 $posts }}
-    {{ partial "components/post-card.html" ( dict
-        "post" .
-        "features" ( dict
-            "smallCards" true
-        )
-    ) }}
+        {{- $dateMachine := .Date | time.Format "2006-01-02T15:04:05-07:00" }}
+        {{- $dateHuman := .Date | time.Format ":date_long" }}
+        {{- $category := index (.GetTerms "categories") 0 }}
+        <li class="post-list-item">
+            <h3><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
+            <div class="post-list-meta">
+                <time datetime="{{ $dateMachine }}">{{ $dateHuman }}</time>
+                {{- with $category }}
+                <span>in <a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></span>
+                {{- end }}
+                {{- with .GetTerms "tags" }}
+                <span>
+                    tagged
+                    {{- range . }} <a href="{{ .RelPermalink }}" class="tag tag--bare">{{ .LinkTitle | lower }}</a>{{- end }}
+                </span>
+                {{- end }}
+            </div>
+        </li>
 {{- end }}
-    </div>
+    </ul>
 </section>
 
 {{/*

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -25,6 +25,16 @@
     </div>
 </section>
 {{- end }}
+
+<section class="home-section">
+    <h2>Popular Tags</h2>
+    <div class="tags">
+    {{- range first 6 .Site.Taxonomies.tags.ByCount }}
+    <a href="{{ .Page.RelPermalink }}" class="tag">{{ .Name }}</a>
+    {{- end }}
+    </div>
+</section>
+
 <section class="home-section">
     <h2>Recent Posts</h2>
     <ul class="post-list">
@@ -37,11 +47,11 @@
             <div class="post-list-meta">
                 <time datetime="{{ $dateMachine }}">{{ $dateHuman }}</time>
                 {{- with $category }}
-                <span>in <a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></span>
+                in <span><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></span>
                 {{- end }}
                 {{- with .GetTerms "tags" }}
+                tagged
                 <span>
-                    tagged
                     {{- range . }} <a href="{{ .RelPermalink }}" class="tag tag--bare">{{ .LinkTitle | lower }}</a>{{- end }}
                 </span>
                 {{- end }}
@@ -50,16 +60,5 @@
 {{- end }}
     </ul>
 </section>
-
-{{/*
-<section class="home-section">
-    <h2>Popular Tags</h2>
-    <div class="tags">
-    {{- range first 6 .Site.Taxonomies.tags.ByCount }}
-    <a href="{{ .Page.RelPermalink }}" class="tag">{{ .Name }}</a>
-    {{- end }}
-    </div>
-</section>
-*/}}
 
 {{ end }}


### PR DESCRIPTION
## Summary

- replace the homepage's recent-post cards with a simple title list
- show each post's publication date, category, and tags
- add lightweight responsive styling for the list metadata

## Why

The simpler layout makes recent posts easier to scan while retaining the key publishing and taxonomy information.

## Validation

- `hugo --environment production`
- `git diff --check`